### PR TITLE
.bin input fix

### DIFF
--- a/inceptor/generators/NativeArtifactGenerator.py
+++ b/inceptor/generators/NativeArtifactGenerator.py
@@ -224,7 +224,6 @@ class NativeArtifactGenerator(Generator):
                 "*.lib",
                 "*.pdb",
                 "*.shc.exe",
-                "*.bin",
                 "coded.txt",
                 "*.obfuscated",
                 "*.exe.config"

--- a/inceptor/inceptor.py
+++ b/inceptor/inceptor.py
@@ -239,9 +239,11 @@ inceptor: A Windows-based PE Packing framework designed to help
     filetype = ext.replace(".", "")
     if filetype == "bin":
         Console.warn_line("[WARNING] File extension '.bin' is not supported, assumed '.raw'")
-        shutil.copy(args.binary, filename + ".raw")
+        ext = ".raw"
+        filetype = ext.replace(".","")
+        shutil.copy(args.binary, filename + ext)
 
-    binary_abs_path = os.path.abspath(args.binary)
+    binary_abs_path = os.path.abspath(filename + ext)
     chain = EncoderChain.from_list(args.encoder)
 
     if args.process:


### PR DESCRIPTION
input file with a .bin extension doesnt work currently because the args.binary variable is used for input.

```
binary_abs_path = os.path.abspath(args.binary)
```

The ".bin" shellcode was also removed in the cleanup process. I resolved this by removing the deletion of .bin in the cleanup function.